### PR TITLE
Copy also gif files to outputs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,7 +138,7 @@ info "Searching outputs..."
 cnt=0
 videos_path="/github/workspace/media/videos/"
 for sce in $scene_names; do
-  video=$(find ${videos_path} -name "${sce}.mp4" -o -name "${sce}.mov" -o -name "${sce}.png")
+  video=$(find ${videos_path} -name "${sce}.mp4" -o -name "${sce}.mov" -o -name "${sce}.png" -o -name "${sce}*.gif")
   output[$cnt]=$video
   cnt=$cnt+1
 done


### PR DESCRIPTION
when rendered w/ `--format=gif` (or deprecated `-i`), it will produce gif videos called `{scene}_ManimCE_v0.12.0.gif` it would be nice to have them also copied over to the output dir